### PR TITLE
Update package.json to match the release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           jq --arg version "$TAG_NAME" '.version = $version' $GITHUB_WORKSPACE/src/version.json > tmp.json && mv tmp.json $GITHUB_WORKSPACE/src/version.json
           TAG_NAME=${TAG_NAME#v} # Remove the 'v' prefix if present
-          jq --arg version "$TAG_NAME" '.version = $version' $GITHUB_WORKSPACE/package.json > tmp.json && mv tmp.json $GITHUB_WORKSPACE/package.json
     
       - uses: grafana/plugin-actions/build-plugin@release
         # Uncomment to enable plugin signing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: echo "The current version is $TAG_NAME"
       
       # Update version.json with the tag name
-      - name: Update version.json and package.json
+      - name: Update version.json
         run: |
           jq --arg version "$TAG_NAME" '.version = $version' $GITHUB_WORKSPACE/src/version.json > tmp.json && mv tmp.json $GITHUB_WORKSPACE/src/version.json
           TAG_NAME=${TAG_NAME#v} # Remove the 'v' prefix if present

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-monitor-app",
-  "version": "1.0.2-pre",
+  "version": "1.0.2",
   "description": "Monitor your Azure Cloud Native services",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "azure-monitor-app",
+  "version": "1.0.1",
   "description": "Monitor your Azure Cloud Native services",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-monitor-app",
-  "version": "1.0.1",
+  "version": "1.0.2-pre",
   "description": "Monitor your Azure Cloud Native services",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "azure-monitor-app",
-  "version": "1.0.0",
   "description": "Monitor your Azure Cloud Native services",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Package.json version needs to match the tag that we release.

Previously we were changing the package.json version in the release flow, but this only changes it in the context of the pipeline.

For revision submission, they still have the version that is checked in, which at the moment is 1.0.0
