### PR TITLE
Fixes navigation, variable and minor data issues

### DIFF
--- a/src/components/SceneApp/Pages/Workloads.ts
+++ b/src/components/SceneApp/Pages/Workloads.ts
@@ -128,7 +128,7 @@ export function getClusterByWorkloadScene(pluginReporter: Reporter) {
       const sceneVars = sceneGraph.getVariables(scene);
       const nsVar = sceneVars.getByName(NS_VARIABLE) as QueryVariable;
       const namespaceVarSub = nsVar.subscribeToState((state) => {
-        if (variableShouldBeCleared(state.options, state.value, sceneVars.isVariableLoadingOrWaitingToUpdate(nsVar))) {
+        if (variableShouldBeCleared(state.options, state.value, state.loading)) {
           nsVar.changeValueTo(VAR_ALL);
         }
       });

--- a/src/components/SceneApp/Queries/ClusterByWorkloadQueries.ts
+++ b/src/components/SceneApp/Queries/ClusterByWorkloadQueries.ts
@@ -250,7 +250,7 @@ function getFieldConfigForField(name: string) {
   const workloadLinks: DataLink[] = [
     {
       title: "Drill down to Compute Resources",
-      url: `/a/${AZURE_MONITORING_PLUGIN_ID}/clusternavigation/workload/computeresources?var-${NS_VARIABLE}=\${__data.fields.namespace}&var-${WORKLOAD_VAR}=\${__data.fields.workload}&\${${PROM_DS_VARIABLE}:queryparam}&\${${CLUSTER_VARIABLE}:queryparam}&\${${SUBSCRIPTION_VARIABLE}:queryparam}&\${__url_time_range}`,
+      url: `/a/${AZURE_MONITORING_PLUGIN_ID}/clusternavigation/workload/computeresources?var-${NS_VARIABLE}=\${__data.fields.namespace}&var-${WORKLOAD_VAR}=\${__data.fields.workload}&\${${PROM_DS_VARIABLE}:queryparam}&\${${AZMON_DS_VARIABLE}:queryparam}&\${${CLUSTER_VARIABLE}:queryparam}&\${${SUBSCRIPTION_VARIABLE}:queryparam}&\${__url_time_range}`,
       targetBlank: false
     }
   ];

--- a/src/components/SceneApp/Queries/ClusterByWorkloadQueries.ts
+++ b/src/components/SceneApp/Queries/ClusterByWorkloadQueries.ts
@@ -195,6 +195,22 @@ export function TransfomClusterByWorkloadData(data: SceneQueryRunner, pluginRepo
                 renameByName: {}
               }
           },
+          {
+            id: "filterByValue",
+            options: {
+              filters: [
+                {
+                  fieldName: "Workload",
+                  config: {
+                    id: "isNotNull",
+                    options: {}
+                  }
+                }
+              ],
+              type: "include",
+              match: "all"
+            }
+          }
         ]
     });
 


### PR DESCRIPTION
**What is and why do we need this feature?**

This PR has multiple minor fixes for:

- drilldown to compute resources not containing the azure monitor datasource variable in the URL
- namespace variable in Workloads not being cleared when the upstream variables change
- fixing the data returned in Workloads table so that any empty workloads are excluded from the results.

**Is this a new feature or a bug fix?**

bug fix


**Link to github issue**
Fixes #22 and #21 
