### PR TITLE
Recognize Azure Prometheus datasource type in datasource checks

### DIFF
--- a/src/components/SceneApp/Pages/Clusters.ts
+++ b/src/components/SceneApp/Pages/Clusters.ts
@@ -6,7 +6,7 @@ import { stringify } from "utils/stringify";
 import { AGG_VAR, AZMON_DS_VARIABLE, ROUTES, SUBSCRIPTION_VARIABLE, VAR_ALL } from "../../../constants";
 import { GetClustersQuery, GetClusterStatsQueries, TransformData } from "../Queries/ClusterMappingQueries";
 import { azure_monitor_queries } from "../Queries/queries";
-import { createMappingFromSeries, getInstanceDatasourcesForType } from "../Queries/queryUtil";
+import { createMappingFromSeries, getInstanceDatasourcesForType, PROM_DS_TYPES } from "../Queries/queryUtil";
 import { getCustomVariable, getDataSourcesVariableForType, getSubscriptionVariable } from "../Variables/variables";
 import { getBehaviorsForVariables, getGenericSceneAppPage, getMissingDatasourceScene, variableShouldBeCleared } from "./sceneUtils";
 import { prefixRoute } from "utils/utils.routing";
@@ -18,7 +18,7 @@ export function getclustersScene(pluginReporter: Reporter): SceneAppPage {
     const sceneUrl = prefixRoute(ROUTES.Clusters);
     // always check first that there is at least one azure monitor datasource
     const azMonDatasources = getInstanceDatasourcesForType("grafana-azure-monitor-datasource");
-    const promDatasources = getInstanceDatasourcesForType("prometheus");
+    const promDatasources = getInstanceDatasourcesForType(PROM_DS_TYPES);
     const reporter = "Scene.Main.ClustersScene";
     const bothDatasourcesMissing = azMonDatasources.length === 0 && promDatasources.length === 0;
     if (azMonDatasources.length === 0) {

--- a/src/components/SceneApp/Pages/Namespaces.ts
+++ b/src/components/SceneApp/Pages/Namespaces.ts
@@ -8,7 +8,7 @@ import { CLUSTER_VARIABLE, PROM_DS_VARIABLE, ROUTES, SUBSCRIPTION_VARIABLE, VAR_
 import { GetClusterOverviewSceneQueries, TranformClusterOverviewData } from "../Queries/ClusterByNamespaceQueries";
 import { GetClustersQuery } from "../Queries/ClusterMappingQueries";
 import { azure_monitor_queries } from "../Queries/queries";
-import { createMappingFromSeries, getInstanceDatasourcesForType, getPromDatasource, getSceneQueryRunner } from "../Queries/queryUtil";
+import { createMappingFromSeries, getInstanceDatasourcesForType, getPromDatasource, getSceneQueryRunner, PROM_DS_TYPES } from "../Queries/queryUtil";
 import { getAlertSummaryDrilldownPage } from "./AlertSummaryDrilldown";
 import { getBehaviorsForVariables, getGenericSceneAppPage, getMissingDatasourceScene, getSharedSceneVariables, variableShouldBeCleared } from "./sceneUtils";
 
@@ -19,7 +19,7 @@ export function getNamespacesScene(pluginReporter: Reporter): SceneAppPage {
     const reporter = "Scene.Main.NamespacesScene";
     // always check first that there is at least one azure monitor datasource
     const azMonDatasources = getInstanceDatasourcesForType("grafana-azure-monitor-datasource");
-    const promDatasources = getInstanceDatasourcesForType("prometheus");
+    const promDatasources = getInstanceDatasourcesForType(PROM_DS_TYPES);
     const bothDatasourcesMissing = azMonDatasources.length === 0 && promDatasources.length === 0;
     if (azMonDatasources.length === 0) {
       const textToShow = bothDatasourcesMissing ? "Azure Monitor or Prometheus" : "Azure Monitor";

--- a/src/components/SceneApp/Pages/Nodes.ts
+++ b/src/components/SceneApp/Pages/Nodes.ts
@@ -7,7 +7,7 @@ import { CLUSTER_VARIABLE, ROUTES, SUBSCRIPTION_VARIABLE } from "../../../consta
 import { GetClustersQuery } from "../Queries/ClusterMappingQueries";
 import { GetNodeOverviewQueries, TransformNodeOverviewData } from "../Queries/NodeOverviewQueries";
 import { azure_monitor_queries } from "../Queries/queries";
-import { createMappingFromSeries, getInstanceDatasourcesForType, getSceneQueryRunner } from "../Queries/queryUtil";
+import { createMappingFromSeries, getInstanceDatasourcesForType, getSceneQueryRunner, PROM_DS_TYPES } from "../Queries/queryUtil";
 import { getBehaviorsForVariables, getGenericSceneAppPage, getMissingDatasourceScene, getSharedSceneVariables, variableShouldBeCleared } from "./sceneUtils";
 import { prefixRoute } from "utils/utils.routing";
 
@@ -17,7 +17,7 @@ export function getOverviewByNodeScene(pluginReporter: Reporter): SceneAppPage {
     const reporter = "Scene.Main.NodesScene";
     // always check first that there is at least one azure monitor datasource
     const azMonDatasources = getInstanceDatasourcesForType("grafana-azure-monitor-datasource");
-    const promDatasources = getInstanceDatasourcesForType("prometheus");
+    const promDatasources = getInstanceDatasourcesForType(PROM_DS_TYPES);
     const bothDatasourcesMissing = azMonDatasources.length === 0 && promDatasources.length === 0;
     if (azMonDatasources.length === 0) {
       const textToShow = bothDatasourcesMissing ? "Azure Monitor or Prometheus" : "Azure Monitor";

--- a/src/components/SceneApp/Pages/Workloads.ts
+++ b/src/components/SceneApp/Pages/Workloads.ts
@@ -8,7 +8,7 @@ import { CLUSTER_VARIABLE, NS_VARIABLE, PROM_DS_VARIABLE, ROUTES, SUBSCRIPTION_V
 import { GetClusterByWorkloadQueries, TransfomClusterByWorkloadData } from '../Queries/ClusterByWorkloadQueries';
 import { GetClustersQuery } from '../Queries/ClusterMappingQueries';
 import { azure_monitor_queries } from '../Queries/queries';
-import { createMappingFromSeries, getInstanceDatasourcesForType, getPromDatasource, getSceneQueryRunner } from '../Queries/queryUtil';
+import { createMappingFromSeries, getInstanceDatasourcesForType, getPromDatasource, getSceneQueryRunner, PROM_DS_TYPES } from '../Queries/queryUtil';
 import { getPrometheusVariable } from '../Variables/variables';
 import { getAlertSummaryDrilldownPage } from './AlertSummaryDrilldown';
 import { getComputeResourcesDrilldownPage } from './ComputeResourcesDrilldown';
@@ -27,7 +27,7 @@ export function getClusterByWorkloadScene(pluginReporter: Reporter) {
   const sceneUrl = prefixRoute(ROUTES.Workloads);
   // always check first that there is at least one azure monitor datasource
   const azMonDatasources = getInstanceDatasourcesForType('grafana-azure-monitor-datasource');
-  const promDatasources = getInstanceDatasourcesForType('prometheus');
+  const promDatasources = getInstanceDatasourcesForType(PROM_DS_TYPES);
   const reporter = 'Scene.Main.WorkloadsScene';
   const bothDatasourcesMissing = azMonDatasources.length === 0 && promDatasources.length === 0;
     if (azMonDatasources.length === 0) {

--- a/src/components/SceneApp/Queries/queryUtil.ts
+++ b/src/components/SceneApp/Queries/queryUtil.ts
@@ -5,6 +5,10 @@ import { ClusterMapping } from "types";
 import { AZMON_DS_VARIABLE } from "../../../constants";
 import { MetricsQueryDimensionFiter } from "./types";
 
+// Datasource plugin types that represent a Prometheus-compatible datasource.
+// Azure Monitor Managed Prometheus can surface either as the core "prometheus"
+// plugin (with Azure auth) or as the dedicated "grafana-azureprometheus-datasource".
+export const PROM_DS_TYPES = ["prometheus", "grafana-azureprometheus-datasource"];
 
 export function getAzureResourceGraphQuery(query: string, subscription: string, refId: string) {
      return {
@@ -96,7 +100,7 @@ export function getSceneQueryRunner(queries: DataQuery[]): SceneQueryRunner {
 }
 export function createMappingFromSeries(workspaces: string[], workspaceIds: string[], clusters: string[], clusterIds: string[],  laws?: string[]): Record<string, ClusterMapping> {
     const datasourceSrv  = getDataSourceSrv();
-    const promDatasources = datasourceSrv.getList().filter((ds) => ds.type === "prometheus") ?? [];
+    const promDatasources = datasourceSrv.getList().filter((ds) => PROM_DS_TYPES.includes(ds.type)) ?? [];
     const clusterMappings: Record<string, ClusterMapping> = {};
     for (let clusterIdx = 0; clusterIdx < clusters.length; clusterIdx++) {
       const cluster = clusters[clusterIdx];
@@ -151,9 +155,10 @@ export function getPromDatasource(clusterMappings: Record<string, ClusterMapping
     return undefined;
 }
 
-export function getInstanceDatasourcesForType(dsType: string) {
+export function getInstanceDatasourcesForType(dsTypes: string | string[]) {
+    const types = Array.isArray(dsTypes) ? dsTypes : [dsTypes];
     const datasourceSrv  = getDataSourceSrv();
-    const foundDatasources = datasourceSrv.getList().filter((ds) => ds.type === dsType) ?? [];
+    const foundDatasources = datasourceSrv.getList().filter((ds) => types.includes(ds.type)) ?? [];
 
     return foundDatasources;
 }


### PR DESCRIPTION
## Problem

The plugin detected Prometheus datasources only via `ds.type === "prometheus"`. In Azure Managed Grafana, an Azure Monitor Workspace can be surfaced through the `grafana-azureprometheus-datasource` plugin. When that is the only Prometheus-type datasource, the plugin:

- shows the "missing Prometheus datasource" landing page on all four main pages (Clusters, Namespaces, Workloads, Nodes), and
- fails to resolve a Prometheus datasource in `createMappingFromSeries`, leaving CPU/memory panels empty.

## Fix

- Add a shared `PROM_DS_TYPES = ["prometheus", "grafana-azureprometheus-datasource"]` constant.
- Use it in both the per-page missing-datasource checks and `createMappingFromSeries`, so the landing-page check and the mapping's candidate list stay in sync.
- `getInstanceDatasourcesForType` now accepts one or more types (backward compatible — existing Azure Monitor callers still pass a single string).

## Testing

- `yarn typecheck` (tsc --noEmit) — pass
- `eslint` on the changed files — pass
- `yarn test:ci` (jest) — pass

## Notes

Part of the investigation into CPU/memory utilization not displaying. This change addresses datasource **type detection** only. Follow-ups still open (not in this PR): endpoint/resource-ID-based datasource matching instead of `directUrl.includes(...)`, the Clusters-tab query race, and per-cluster datasource selection on the Namespaces/Workloads tabs.
