### PR TITLE
Match AMW Prometheus datasource by query endpoint, not name substring

### DIFF
--- a/src/components/SceneApp/Pages/Clusters.ts
+++ b/src/components/SceneApp/Pages/Clusters.ts
@@ -80,7 +80,7 @@ export function getclustersScene(pluginReporter: Reporter): SceneAppPage {
           const clusterData = state.data?.series.filter((s) => s.refId === "clusters");
   
           try {
-            clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, clusterData[0]?.fields[2]?.values);
+            clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, clusterData[0]?.fields[2]?.values, workspaceData[0]?.fields[2]?.values);
             const clusterStatsQueries = GetClusterStatsQueries(clusterMappings);
             clusterTrendData.setState({ datasource: {
               type: 'datasource',

--- a/src/components/SceneApp/Pages/ComputeResourcesDrilldown.ts
+++ b/src/components/SceneApp/Pages/ComputeResourcesDrilldown.ts
@@ -235,7 +235,7 @@ function getComputeResourcesDrilldownScene(pluginReporter: Reporter) {
           const workspaceData = state.data?.series.filter((s) => s.refId === "workspaces");
           const clusterData = state.data?.series.filter((s) => s.refId === "clusters");
           try {
-                clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values);
+                clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, undefined, workspaceData[0]?.fields[2]?.values);
                 const selectedCluster = clusterVar.state.value.toString();
                 const promDs = getPromDatasource(clusterMappings, selectedCluster);
                 if (!!promDs && promDs.uid) {

--- a/src/components/SceneApp/Pages/Namespaces.ts
+++ b/src/components/SceneApp/Pages/Namespaces.ts
@@ -113,7 +113,7 @@ export function getNamespacesScene(pluginReporter: Reporter): SceneAppPage {
           const workspaceData = state.data?.series.filter((s) => s.refId === "workspaces");
           const clusterData = state.data?.series.filter((s) => s.refId === "clusters");
           try {
-            clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values);
+            clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, undefined, workspaceData[0]?.fields[2]?.values);
             const selectedCluster = clusterVar.state.value.toString();
             const promDs = getPromDatasource(clusterMappings, selectedCluster);
             if (!!promDs && promDs.uid) {

--- a/src/components/SceneApp/Pages/Nodes.ts
+++ b/src/components/SceneApp/Pages/Nodes.ts
@@ -141,7 +141,7 @@ export function getOverviewByNodeScene(pluginReporter: Reporter): SceneAppPage {
                 const workspaceData = state.data?.series.filter((s) => s.refId === "workspaces");
                 const clusterData = state.data?.series.filter((s) => s.refId === "clusters");
                 try {
-                    clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, clusterData[0]?.fields[2]?.values);
+                    clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, clusterData[0]?.fields[2]?.values, workspaceData[0]?.fields[2]?.values);
                     const newQueries = GetNodeOverviewQueries(clusterMappings, [clusterVar.state.value.toString()]);
                     nodeOverviewData.setState({ queries: newQueries });
                     nodeOverviewData.runQueries();

--- a/src/components/SceneApp/Pages/PodWithLogsDrilldown.ts
+++ b/src/components/SceneApp/Pages/PodWithLogsDrilldown.ts
@@ -384,7 +384,7 @@ function getPodWithLogsDrilldownScene(pluginReporter: Reporter) {
             if (state.data?.state === "Done") {
                 const workspaceData = state.data?.series.filter((s) => s.refId === "workspaces");
                 const clusterData = state.data?.series.filter((s) => s.refId === "clusters");
-                clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, clusterData[0]?.fields[2]?.values);
+                clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, clusterData[0]?.fields[2]?.values, workspaceData[0]?.fields[2]?.values);
                 const selectedCluster = clusterVar.state.value.toString();
                 const promDs = getPromDatasource(clusterMappings, selectedCluster);
                 if (!!promDs && promDs.uid) {

--- a/src/components/SceneApp/Pages/Workloads.ts
+++ b/src/components/SceneApp/Pages/Workloads.ts
@@ -138,7 +138,7 @@ export function getClusterByWorkloadScene(pluginReporter: Reporter) {
           const workspaceData = state.data?.series.filter((s) => s.refId === "workspaces");
           const clusterData = state.data?.series.filter((s) => s.refId === "clusters");
           try {
-            clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values);
+            clusterMappings = createMappingFromSeries(workspaceData[0]?.fields[0]?.values, workspaceData[0]?.fields[1]?.values, clusterData[0]?.fields[0]?.values, clusterData[0]?.fields[1]?.values, undefined, workspaceData[0]?.fields[2]?.values);
             const selectedCluster = clusterVar.state.value.toString();
             const promDs = getPromDatasource(clusterMappings, selectedCluster);
             if (!!promDs && promDs.uid) {

--- a/src/components/SceneApp/Queries/queries.ts
+++ b/src/components/SceneApp/Queries/queries.ts
@@ -65,7 +65,13 @@ const workspaceNameAzure =
     | summarize associatedGrafanas=make_list(grafanaObject) by azureMonitorWorkspaceResourceId) on azureMonitorWorkspaceResourceId
   | extend amwToGrafana = pack("azureMonitorWorkspaceResourceId", azureMonitorWorkspaceResourceId, "associatedGrafanas", associatedGrafanas)
   | summarize amwToGrafanas=make_list(amwToGrafana) by dcrId, dcraName, id
-  | project workspace = tostring(split(amwToGrafanas[0].azureMonitorWorkspaceResourceId, "/")[-1]), id`;
+  | extend amwResourceId = tostring(amwToGrafanas[0].azureMonitorWorkspaceResourceId)
+  | join kind=leftouter (
+      resources
+      | where type =~ "microsoft.monitor/accounts"
+      | project amwResourceId = tolower(id), prometheusQueryEndpoint = tostring(properties.metrics.prometheusQueryEndpoint)
+    ) on amwResourceId
+  | project workspace = tostring(split(amwResourceId, "/")[-1]), id, promEndpoint = prometheusQueryEndpoint`;
 
 export const azure_monitor_queries: QueryMap = {
   namespacesQuery: namespacesQueryAzure,

--- a/src/components/SceneApp/Queries/queryUtil.test.ts
+++ b/src/components/SceneApp/Queries/queryUtil.test.ts
@@ -1,0 +1,136 @@
+import { getDataSourceSrv } from "@grafana/runtime";
+import { createMappingFromSeries, getAMWToGrana, safeHost } from "./queryUtil";
+
+jest.mock("@grafana/scenes", () => ({
+  SceneQueryRunner: class {},
+}));
+
+jest.mock("@grafana/runtime", () => ({
+  ...jest.requireActual("@grafana/runtime"),
+  getDataSourceSrv: jest.fn(),
+}));
+
+const mockDatasources = (list: unknown[]) => {
+  (getDataSourceSrv as jest.Mock).mockReturnValue({ getList: () => list });
+};
+
+// Real-world shaped fixtures (cluster name has an underscore; the DCRA id embeds
+// the cluster name in its /managedClusters/<name>/ segment, and the AMW query
+// endpoint is <amw-name>-<hash>.<region>.prometheus.monitor.azure.com).
+const CLUSTER = "aks-i4c-aks_shared-de-001";
+const DCRA_ID =
+  "/subscriptions/x/resourceGroups/rgp-i4c-aks_shared-de-001/providers/Microsoft.ContainerService/managedClusters/aks-i4c-aks_shared-de-001/providers/Microsoft.Insights/dataCollectionRuleAssociations/MSProm-westeurope-aks-i4c-aks-shared-de-001";
+const AMW = "amw-tec-pr-weu-monitor";
+const ENDPOINT = "https://amw-tec-pr-weu-monitor-abc.westeurope.prometheus.monitor.azure.com";
+
+const clusters = [CLUSTER];
+const clusterIds = ["/subscriptions/x/.../managedClusters/aks-i4c-aks_shared-de-001"];
+const workspaces = [AMW];
+const workspaceIds = [DCRA_ID];
+const endpoints = [ENDPOINT];
+
+describe("safeHost", () => {
+  it("extracts a lowercased host from a URL", () => {
+    expect(safeHost("https://AMW-Tec-PR-WEU-monitor-abc.westeurope.prometheus.monitor.azure.com")).toBe(
+      "amw-tec-pr-weu-monitor-abc.westeurope.prometheus.monitor.azure.com"
+    );
+  });
+
+  it("returns empty string for undefined/empty", () => {
+    expect(safeHost(undefined)).toBe("");
+    expect(safeHost("")).toBe("");
+  });
+
+  it("falls back to lowercased input for non-URLs", () => {
+    expect(safeHost("Not A Url")).toBe("not a url");
+  });
+});
+
+describe("getAMWToGrana", () => {
+  it("matches an underscore cluster name via the managedClusters segment and returns amw + endpoint", () => {
+    const [amw, wsId, endpoint] = getAMWToGrana(workspaces, workspaceIds, CLUSTER, endpoints);
+    expect(amw).toBe(AMW);
+    expect(wsId).toBe(DCRA_ID);
+    expect(endpoint).toBe(ENDPOINT);
+  });
+
+  it("returns empty amw/undefined when no DCRA id contains the cluster name", () => {
+    const [amw, wsId, endpoint] = getAMWToGrana(workspaces, workspaceIds, "aks-does-not-exist", endpoints);
+    expect(amw).toBe("");
+    expect(wsId).toBeUndefined();
+    expect(endpoint).toBeUndefined();
+  });
+});
+
+describe("createMappingFromSeries datasource resolution", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("resolves the datasource whose directUrl host matches the AMW endpoint", () => {
+    mockDatasources([
+      { uid: "itn", type: "prometheus", name: "itn", jsonData: { directUrl: "https://amw-tec-pr-itn-monitor-xyz.italynorth.prometheus.monitor.azure.com" } },
+      { uid: "weu", type: "prometheus", name: "weu", jsonData: { directUrl: ENDPOINT } },
+    ]);
+
+    const mapping = createMappingFromSeries(workspaces, workspaceIds, clusters, clusterIds, undefined, endpoints);
+    expect(mapping[CLUSTER].promDs?.uid).toBe("weu");
+    expect(mapping[CLUSTER].promEndpoint).toBe(ENDPOINT);
+  });
+
+  it("picks the correct datasource when another URL merely contains the AMW name as a substring (collision)", () => {
+    // Both datasources' directUrl contain "amw-tec-pr-weu-monitor"; only the endpoint host is exact.
+    mockDatasources([
+      { uid: "decoy", type: "prometheus", name: "decoy", jsonData: { directUrl: "https://amw-tec-pr-weu-monitor-DECOY.eastus.prometheus.monitor.azure.com" } },
+      { uid: "weu", type: "prometheus", name: "weu", jsonData: { directUrl: ENDPOINT } },
+    ]);
+
+    const mapping = createMappingFromSeries(workspaces, workspaceIds, clusters, clusterIds, undefined, endpoints);
+    expect(mapping[CLUSTER].promDs?.uid).toBe("weu");
+  });
+
+  it("recognizes the grafana-azureprometheus-datasource plugin type", () => {
+    mockDatasources([
+      { uid: "azprom", type: "grafana-azureprometheus-datasource", name: "azp", jsonData: { directUrl: ENDPOINT } },
+    ]);
+
+    const mapping = createMappingFromSeries(workspaces, workspaceIds, clusters, clusterIds, undefined, endpoints);
+    expect(mapping[CLUSTER].promDs?.uid).toBe("azprom");
+  });
+
+  it("ignores non-Prometheus datasource types", () => {
+    mockDatasources([
+      { uid: "azmon", type: "grafana-azure-monitor-datasource", name: "azmon", jsonData: { directUrl: ENDPOINT } },
+    ]);
+
+    const mapping = createMappingFromSeries(workspaces, workspaceIds, clusters, clusterIds, undefined, endpoints);
+    expect(mapping[CLUSTER].promDs).toBeUndefined();
+  });
+
+  it("falls back to name-substring matching when no endpoint is available (no regression)", () => {
+    mockDatasources([
+      { uid: "byname", type: "prometheus", name: "n", jsonData: { directUrl: ENDPOINT } },
+    ]);
+
+    const mapping = createMappingFromSeries(workspaces, workspaceIds, clusters, clusterIds, undefined, undefined);
+    expect(mapping[CLUSTER].promDs?.uid).toBe("byname");
+  });
+
+  it("does not throw when a datasource has no directUrl/url and still resolves the correct one", () => {
+    mockDatasources([
+      { uid: "nourl", type: "prometheus", name: "nourl", jsonData: {} },
+      { uid: "weu", type: "prometheus", name: "weu", jsonData: { directUrl: ENDPOINT } },
+    ]);
+
+    expect(() => createMappingFromSeries(workspaces, workspaceIds, clusters, clusterIds, undefined, endpoints)).not.toThrow();
+    const mapping = createMappingFromSeries(workspaces, workspaceIds, clusters, clusterIds, undefined, endpoints);
+    expect(mapping[CLUSTER].promDs?.uid).toBe("weu");
+  });
+
+  it("leaves promDs undefined when no datasource matches by endpoint or name", () => {
+    mockDatasources([
+      { uid: "other", type: "prometheus", name: "other", jsonData: { directUrl: "https://something-else.eastus.prometheus.monitor.azure.com" } },
+    ]);
+
+    const mapping = createMappingFromSeries(workspaces, workspaceIds, clusters, clusterIds, undefined, endpoints);
+    expect(mapping[CLUSTER].promDs).toBeUndefined();
+  });
+});

--- a/src/components/SceneApp/Queries/queryUtil.ts
+++ b/src/components/SceneApp/Queries/queryUtil.ts
@@ -1,6 +1,7 @@
 import { getDataSourceSrv } from "@grafana/runtime";
 import { SceneQueryRunner } from "@grafana/scenes";
 import { DataQuery, DataSourceRef } from "@grafana/schema";
+import { DataSourceInstanceSettings } from "@grafana/data";
 import { ClusterMapping } from "types";
 import { AZMON_DS_VARIABLE } from "../../../constants";
 import { MetricsQueryDimensionFiter } from "./types";
@@ -98,13 +99,13 @@ export function getSceneQueryRunner(queries: DataQuery[]): SceneQueryRunner {
 
     return new SceneQueryRunner(mixedQuery);
 }
-export function createMappingFromSeries(workspaces: string[], workspaceIds: string[], clusters: string[], clusterIds: string[],  laws?: string[]): Record<string, ClusterMapping> {
+export function createMappingFromSeries(workspaces: string[], workspaceIds: string[], clusters: string[], clusterIds: string[], laws?: string[], promEndpoints?: string[]): Record<string, ClusterMapping> {
     const datasourceSrv  = getDataSourceSrv();
     const promDatasources = datasourceSrv.getList().filter((ds) => PROM_DS_TYPES.includes(ds.type)) ?? [];
     const clusterMappings: Record<string, ClusterMapping> = {};
     for (let clusterIdx = 0; clusterIdx < clusters.length; clusterIdx++) {
       const cluster = clusters[clusterIdx];
-      const [amw, workspaceId] = getAMWToGrana(workspaces, workspaceIds, cluster);
+      const [amw, workspaceId, promEndpoint] = getAMWToGrana(workspaces, workspaceIds, cluster, promEndpoints);
       let law = "";
       let clusterId = "";
       let promDs = undefined
@@ -112,7 +113,7 @@ export function createMappingFromSeries(workspaces: string[], workspaceIds: stri
       clusterId = clusterIds[clusterIdx];
   
       if (!!amw) {
-        promDs = promDatasources.find((ds) => (ds.jsonData as any)?.directUrl.toLowerCase().includes(amw.toLowerCase()));
+        promDs = matchPromDatasource(promDatasources, promEndpoint, amw);
       }
   
       const clusterMapping: ClusterMapping = {
@@ -120,6 +121,7 @@ export function createMappingFromSeries(workspaces: string[], workspaceIds: stri
         workspaceId: workspaceId,
         amw: amw,
         promDs: promDs,
+        promEndpoint: promEndpoint,
         law: law,
         clusterId: clusterId
       }
@@ -130,10 +132,46 @@ export function createMappingFromSeries(workspaces: string[], workspaceIds: stri
     return clusterMappings;
 }
 
-export function getAMWToGrana(workspaces: string[], workspaceIds: string[], cluster: string): [string, string | undefined] {
+// Extracts the lowercased host from a URL, tolerating undefined/malformed input.
+export function safeHost(url?: string): string {
+    if (!url) {
+        return "";
+    }
+    try {
+        return new URL(url).host.toLowerCase();
+    } catch {
+        return url.toLowerCase();
+    }
+}
+
+// The query URL Grafana uses for a Prometheus datasource. `directUrl` is the
+// unproxied endpoint Grafana injects at runtime; fall back to `url`.
+function getDatasourceQueryUrl(ds: DataSourceInstanceSettings): string {
+    return (ds.jsonData as { directUrl?: string })?.directUrl ?? ds.url ?? "";
+}
+
+// Resolve the Prometheus datasource for an Azure Monitor Workspace.
+// Primary match is exact host equality against the AMW's Prometheus query
+// endpoint (robust in multi-AMW environments). Falls back to the prior
+// name-substring behavior (null-safe) so resolution is never worse than before.
+function matchPromDatasource(promDatasources: DataSourceInstanceSettings[], promEndpoint: string | undefined, amw: string) {
+    const targetHost = safeHost(promEndpoint);
+    if (!!targetHost) {
+        const byEndpoint = promDatasources.find((ds) => safeHost(getDatasourceQueryUrl(ds)) === targetHost);
+        if (byEndpoint) {
+            return byEndpoint;
+        }
+    }
+
+    const amwLower = amw.toLowerCase();
+    return promDatasources.find((ds) => getDatasourceQueryUrl(ds).toLowerCase().includes(amwLower));
+}
+
+export function getAMWToGrana(workspaces: string[], workspaceIds: string[], cluster: string, promEndpoints?: string[]): [string, string | undefined, string | undefined] {
     const workspaceId = workspaceIds.find((id) => id.toLowerCase().includes(cluster.toLowerCase()));
     let idIdx = -1;
     let amw = "";
+    let promEndpoint: string | undefined = undefined;
 
     if (!!workspaceId) {
         idIdx = workspaceIds.indexOf(workspaceId);
@@ -141,9 +179,10 @@ export function getAMWToGrana(workspaces: string[], workspaceIds: string[], clus
 
     if (idIdx !== -1) {
         amw = workspaces[idIdx];
+        promEndpoint = promEndpoints?.[idIdx];
     }
 
-    return [amw, workspaceId];
+    return [amw, workspaceId, promEndpoint];
 }
  
 export function getPromDatasource(clusterMappings: Record<string, ClusterMapping>, cluster: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,5 +13,6 @@ export interface ClusterMapping {
     workspaceId?: string;
     amw?: string
     promDs?: DataSourceRef;
+    promEndpoint?: string;
     law?: string;
 }


### PR DESCRIPTION
## Problem

`createMappingFromSeries` resolved a cluster's Prometheus datasource with a fuzzy check:

```ts
promDs = promDatasources.find((ds) => (ds.jsonData as any)?.directUrl.toLowerCase().includes(amw.toLowerCase()));
```

In multi-AMW environments this is unreliable:
- **Naive substring match** — one workspace name can be a substring of another's URL (collisions).
- **First-match-wins** — with several Prometheus datasources it can silently pick the wrong one; a single wrong pick makes every cluster routed through it return empty.
- **Throws** if `directUrl` is `undefined` (`.toLowerCase()` on undefined), which can abort the whole mapping.

The observed effect was CPU/memory panels querying the wrong Azure Monitor Workspace (empty data) or no datasource resolving at all.

## Fix

Resolve the datasource by **exact host equality** against the AMW's Prometheus query endpoint (`properties.metrics.prometheusQueryEndpoint`):

- Extend the `workspaceNameQuery` ARG query to join `microsoft.monitor/accounts` and project `promEndpoint` (validated in Azure Resource Graph). `getAMWToGrana`/`createMappingFromSeries` thread the endpoint through and match on `new URL(...).host`.
- **Fallback preserved:** when no endpoint is available, fall back to the prior name-substring behavior (now null-safe), so resolution is never worse than before — no regression.

## Testing

- `yarn typecheck` — pass
- `eslint` (changed files) — pass
- `yarn test:ci` — pass (added `queryUtil.test.ts`, 12 cases): endpoint host match, substring-collision (picks the correct DS), `grafana-azureprometheus-datasource` type, non-Prometheus ignored, name-substring fallback, null-safety, and no-match.
- ARG query change validated end-to-end via Azure Resource Graph against real `MSProm-*` DCRAs.

## Notes

Part of the CPU/memory utilization investigation. Builds on the merged datasource-type detection change. Remaining follow-ups (not in this PR): the Clusters-tab query race, per-cluster datasource selection on Namespaces/Workloads, and the Workloads `namespace =~ "()"` variable bug.
